### PR TITLE
change debug to a peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
     "node",
     "worker"
   ],
-  "dependencies": {
-    "debug": "^3.1.0"
+  "peerDependencies": {
+    "debug": ">=1.0.0 <5.0.0"
   },
   "devDependencies": {
     "eslint": "^4.18.0"


### PR DESCRIPTION
No need to push `^3.0.0` on users if we don't have to?